### PR TITLE
Fixes Issue #SSO-60

### DIFF
--- a/module/Group/src/Model/Group.php
+++ b/module/Group/src/Model/Group.php
@@ -38,21 +38,6 @@ class Group extends Model implements HasSlugInterface
     ];
 
     /**
-     * String for district's logo file.
-     */
-    public $logoFilename;
-
-    /**
-     * String for Group's brand/header color.
-     */
-    public $themeColor;
-
-    /**
-     * String for Group's background color.
-     */
-    public $backgroundColor;
-
-    /**
      * InputFilter for Group's inputFilter.
      */
     protected $inputFilter;


### PR DESCRIPTION
Fixes Issue #SSO-60 by removing the theme properties from the model.

The properties will now be loaded as attributes from the database and (thanks to the magic get method) can be accessed in the same manner.